### PR TITLE
remove required params form hide_keyboard

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -324,7 +324,7 @@ const METHOD_MAP = {
     POST: {command: 'isAppInstalled', payloadParams: {required: ['bundleId']}}
   },
   '/wd/hub/session/:sessionId/appium/device/hide_keyboard': {
-    POST: {command: 'hideKeyboard', payloadParams: {required: ['key', 'keyName', 'strategy']}}
+    POST: {command: 'hideKeyboard', payloadParams: {optional: ['strategy', 'key', 'keyCode']}}
   },
   '/wd/hub/session/:sessionId/appium/device/push_file': {
     POST: {command: 'pushFile', payloadParams: {required: ['path', 'data']}}

--- a/test/routes-specs.js
+++ b/test/routes-specs.js
@@ -34,7 +34,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('1f470dfd');
+      hash.should.equal('d6e2a3ac');
     });
   });
 


### PR DESCRIPTION
@imurchie is this the right way to do this?
In reality, this command can either be called with no parameters, `strategy`, `keyname`, `key`, or some combination thereof.