### PR TITLE
adds wrap option to payload params + test fixes

### DIFF
--- a/lib/mjsonwp.js
+++ b/lib/mjsonwp.js
@@ -16,6 +16,12 @@ function isSessionCommand (command) {
 }
 
 function wrapParams (paramSets, jsonObj) {
+  /* There are commands like performTouch which take a single parameter (primitive type or array).
+   * Some drivers choose to pass this parameter as a value (eg. [action1, action2...]) while others to
+   * wrap it within an object(eg' {gesture:  [action1, action2...]}), which makes it hard to validate.
+   * The wrap option in the spec enforce wrapping before validation, so that all params are wrapped at
+   * the time they are validated and later passed to the commands.
+   */
   let res = jsonObj;
   if (paramSets && paramSets.wrap && (_.isArray(jsonObj) || !_.isObject(jsonObj))) {
     res = {};

--- a/lib/mjsonwp.js
+++ b/lib/mjsonwp.js
@@ -15,11 +15,21 @@ function isSessionCommand (command) {
   return !_.contains(NO_SESSION_ID_COMMANDS, command);
 }
 
+function wrapParams (paramSets, jsonObj) {
+  let res = jsonObj;
+  if (paramSets && paramSets.wrap && (_.isArray(jsonObj) || !_.isObject(jsonObj))) {
+    res = {};
+    res[paramSets.wrap] = jsonObj;
+  }
+  return res;
+}
+
 function checkParams (paramSets, jsonObj) {
-  let receivedParams = _.keys(jsonObj);
+
   let wrongParams = false;
   let requiredParams = []
     , optionalParams = [];
+  let receivedParams = _.keys(jsonObj);
   if (paramSets) {
     if (paramSets.required) {
       // we might have an array of parameters,
@@ -127,6 +137,9 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       if (!spec.command) {
         throw new errors.NotImplementedError();
       }
+
+      // wrap params if necessary
+      jsonObj = wrapParams(spec.payloadParams, jsonObj);
 
       // ensure that the json payload conforms to the spec
       checkParams(spec.payloadParams, jsonObj);

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -282,7 +282,7 @@ const METHOD_MAP = {
     POST: {command: 'performTouch', payloadParams: {wrap: 'gestures' ,required: ['gestures']}}
   },
   '/wd/hub/session/:sessionId/touch/multi/perform': {
-    POST: {command: 'performMultiAction', payloadParams: {required: ['elementId', 'actions']}}
+    POST: {command: 'performMultiAction', payloadParams: {required: ['actions'], optional: ['elementId']}}
   },
   '/wd/hub/session/:sessionId/receive_async_response': {
     POST: {command: 'receiveAsyncResponse', payloadParams: {required: ['response']}}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -279,7 +279,7 @@ const METHOD_MAP = {
     POST: {command: 'setNetworkConnection', payloadParams: {required: ['type']}}
   },
   '/wd/hub/session/:sessionId/touch/perform': {
-    POST: {command: 'performTouch', payloadParams: {required: ['gestures']}}
+    POST: {command: 'performTouch', payloadParams: {wrap: 'gestures' ,required: ['gestures']}}
   },
   '/wd/hub/session/:sessionId/touch/multi/perform': {
     POST: {command: 'performMultiAction', payloadParams: {required: ['elementId', 'actions']}}

--- a/test/fake-driver.js
+++ b/test/fake-driver.js
@@ -87,6 +87,11 @@ class FakeDriver extends MobileJsonWireProtocol {
     return [attr, elementId, sessionId];
   }
 
+  async performTouch (...args) {
+    return args;
+  }
+
+
 }
 
 export { FakeDriver };

--- a/test/mjsonwp-specs.js
+++ b/test/mjsonwp-specs.js
@@ -12,7 +12,7 @@ import 'mochawait';
 let should = chai.should();
 chai.use(chaiAsPromised);
 
-describe('MJSONWP', () => {
+describe('MJSONWP', async () => {
 
   //TODO: more tests!:
   // Unknown commands should return 404
@@ -25,11 +25,12 @@ describe('MJSONWP', () => {
   });
 
   describe('via express router', () => {
-    let driver = new FakeDriver();
-    driver.sessionId = 'foo';
     let mjsonwpServer;
+    let driver;
 
     before(async () => {
+      driver = new FakeDriver();
+      driver.sessionId = 'foo';
       mjsonwpServer = await server(routeConfiguringFunction(driver), 8181);
     });
 
@@ -186,7 +187,7 @@ describe('MJSONWP', () => {
       }).should.eventually.be.rejectedWith("400");
     });
 
-    describe('multiple sets of arguments', async () => {
+    describe('multiple sets of arguments', () => {
       it('should allow moveto with element', async () => {
         let res = await request({
           url: 'http://localhost:8181/wd/hub/session/foo/moveto',
@@ -212,6 +213,28 @@ describe('MJSONWP', () => {
           json: {}
         }).should.eventually.be.rejectedWith('400');
       });
+    });
+
+    describe('default param wrap', () => {
+
+      it('should wrap', async () => {
+        let res = await request({
+          url: 'http://localhost:8181/wd/hub/session/foo/touch/perform',
+          method: 'POST',
+          json: [{"action":"tap","options":{"element":"3"}}]
+        });
+        res.value.should.deep.equal([[{"action":"tap","options":{"element":"3"}}], 'foo']);
+      });
+
+      it('should not wrap twice', async () => {
+        let res = await request({
+          url: 'http://localhost:8181/wd/hub/session/foo/touch/perform',
+          method: 'POST',
+          json: {gestures: [{"action":"tap","options":{"element":"3"}}]}
+        });
+        res.value.should.deep.equal([[{"action":"tap","options":{"element":"3"}}], 'foo']);
+      });
+
     });
 
     describe('optional sets of arguments', async () => {

--- a/test/routes-specs.js
+++ b/test/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('114d714d');
+      hash.should.equal('3135f259');
     });
   });
 

--- a/test/routes-specs.js
+++ b/test/routes-specs.js
@@ -29,12 +29,16 @@ describe('MJSONWP', () => {
             for (let param of allParams) {
               shasum.update(param);
             }
+            if (methodMapping.payloadParams.wrap) {
+              shasum.update('skip');
+              shasum.update(methodMapping.payloadParams.wrap);
+            }
           }
         }
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('4f102aba');
+      hash.should.equal('114d714d');
     });
   });
 


### PR DESCRIPTION
This is for command like performTouch, where the gestures may be passed as an array (WD.js) or wrapped within an object (Python driver). The wrap param wrap arrays and non object type into the expected format, so that the validation passes.

Also cleaned up the test.

ping @jlipps  @moizjv   