### PR TITLE
Unwrap params

### DIFF
--- a/lib/mjsonwp.js
+++ b/lib/mjsonwp.js
@@ -23,9 +23,20 @@ function wrapParams (paramSets, jsonObj) {
    * the time they are validated and later passed to the commands.
    */
   let res = jsonObj;
-  if (paramSets && paramSets.wrap && (_.isArray(jsonObj) || !_.isObject(jsonObj))) {
+  if (_.isArray(jsonObj) || !_.isObject(jsonObj)) {
     res = {};
     res[paramSets.wrap] = jsonObj;
+  }
+  return res;
+}
+
+function unwrapParams (paramSets, jsonObj) {
+  /* There are commands like setNetworkConnection which send parameters wrapped inside a key such as
+   * "parameters". This function unwraps them (eg. {"parameters": {"type": 1}} becomes {"type": 1}).
+   */
+  let res = jsonObj;
+  if (_.isObject(jsonObj)) {
+    res = jsonObj[paramSets.unwrap];
   }
   return res;
 }
@@ -145,7 +156,14 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       }
 
       // wrap params if necessary
-      jsonObj = wrapParams(spec.payloadParams, jsonObj);
+      if (spec.payloadParams && spec.payloadParams.wrap) {
+        jsonObj = wrapParams(spec.payloadParams, jsonObj);
+      }
+
+      // unwrap params if necessary
+      if (spec.payloadParams && spec.payloadParams.unwrap) {
+        jsonObj = unwrapParams(spec.payloadParams, jsonObj);
+      }
 
       // ensure that the json payload conforms to the spec
       checkParams(spec.payloadParams, jsonObj);

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -276,10 +276,10 @@ const METHOD_MAP = {
   },
   '/wd/hub/session/:sessionId/network_connection': {
     GET: {command: 'getNetworkConnection'},
-    POST: {command: 'setNetworkConnection', payloadParams: {required: ['type']}}
+    POST: {command: 'setNetworkConnection', payloadParams: {unwrap: 'parameters', required: ['type']}}
   },
   '/wd/hub/session/:sessionId/touch/perform': {
-    POST: {command: 'performTouch', payloadParams: {wrap: 'gestures' ,required: ['gestures']}}
+    POST: {command: 'performTouch', payloadParams: {wrap: 'gestures', required: ['gestures']}}
   },
   '/wd/hub/session/:sessionId/touch/multi/perform': {
     POST: {command: 'performMultiAction', payloadParams: {required: ['actions'], optional: ['elementId']}}


### PR DESCRIPTION
New function "unwrapParams" which turns `{"params": {"foo": "bar"}}` into `{"foo": "bar"}`