### PR TITLE
Remove special handling of not implemented error

### DIFF
--- a/lib/mjsonwp.js
+++ b/lib/mjsonwp.js
@@ -91,10 +91,6 @@ function getResponseForJsonwpError (err) {
     log.debug('Bad parameters:', err);
     httpStatus = 400;
     httpResBody = err.message;
-  } else if (isErrorType(err, errors.NotYetImplementedError) ||
-             isErrorType(err, errors.NotImplementedError)) {
-    httpStatus = 501;
-    httpResBody = err.message;
   }
   return [httpStatus, httpResBody];
 }


### PR DESCRIPTION
No need to especially handle not implemented and not yet implemented errors. With the special handling the client didn't know what to do. This way they come as Unknown Errors.