### PR TITLE
Allow sessionId in params

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+coverage

--- a/lib/mjsonwp.js
+++ b/lib/mjsonwp.js
@@ -46,6 +46,7 @@ function checkParams (paramSets, jsonObj) {
   let requiredParams = [];
   let optionalParams = [];
   let receivedParams = _.keys(jsonObj);
+
   if (paramSets) {
     if (paramSets.required) {
       // we might have an array of parameters,
@@ -61,6 +62,10 @@ function checkParams (paramSets, jsonObj) {
       optionalParams = paramSets.optional;
     }
   }
+
+  // some clients pass in the session id in the params
+  optionalParams.push('sessionId');
+
   for (let params of requiredParams) {
     if (_.difference(receivedParams, params, optionalParams).length === 0 &&
         _.difference(params, receivedParams).length === 0) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "watch": "./node_modules/.bin/gulp"
   },
   "devDependencies": {
-    "appium-express": "latest",
+    "appium-express": "^1.0.0",
     "appium-gulp-plugins": "^1.3.11",
     "chai": "^3.2.0",
     "chai-as-promised": "^5.0.0",

--- a/test/mjsonwp-specs.js
+++ b/test/mjsonwp-specs.js
@@ -2,7 +2,7 @@
 
 import { routeConfiguringFunction } from '../index';
 import { FakeDriver } from './fake-driver';
-import { server } from 'appium-express';
+import server from 'appium-express';
 import _ from 'lodash';
 import request from 'request-promise';
 import chai from 'chai';

--- a/test/routes-specs.js
+++ b/test/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('2fe7488e');
+      hash.should.equal('e82d32a2');
     });
   });
 


### PR DESCRIPTION
Some clients (like Python) send in `sessionId` with the params as well as part of the url. Allow them through.

Resolves https://github.com/appium/python-client/issues/105