### PR TITLE
Change gestures to actions in parameters to touch/perform

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -280,7 +280,7 @@ const METHOD_MAP = {
     POST: {command: 'setNetworkConnection', payloadParams: {unwrap: 'parameters', required: ['type']}}
   },
   '/wd/hub/session/:sessionId/touch/perform': {
-    POST: {command: 'performTouch', payloadParams: {wrap: 'gestures', required: ['gestures']}}
+    POST: {command: 'performTouch', payloadParams: {wrap: 'actions', required: ['actions']}}
   },
   '/wd/hub/session/:sessionId/touch/multi/perform': {
     POST: {command: 'performMultiAction', payloadParams: {required: ['actions'], optional: ['elementId']}}

--- a/test/mjsonwp-specs.js
+++ b/test/mjsonwp-specs.js
@@ -235,7 +235,7 @@ describe('MJSONWP', async () => {
         let res = await request({
           url: 'http://localhost:8181/wd/hub/session/foo/touch/perform',
           method: 'POST',
-          json: {gestures: [{"action":"tap","options":{"element":"3"}}]}
+          json: {actions: [{"action":"tap","options":{"element":"3"}}]}
         });
         res.value.should.deep.equal([[{"action":"tap","options":{"element":"3"}}], 'foo']);
       });

--- a/test/routes-specs.js
+++ b/test/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('e82d32a2');
+      hash.should.equal('1fee7e7f');
     });
   });
 


### PR DESCRIPTION
Clients send `actions` instead of `gestures`.