### PR TITLE
Use 404 for driver not found errors

### DIFF
--- a/lib/mjsonwp.js
+++ b/lib/mjsonwp.js
@@ -108,6 +108,9 @@ function getResponseForJsonwpError (err) {
              isErrorType(err, errors.NotImplementedError)) {
     // respond with a 501 if the method is not implemented
     httpStatus = 501;
+  } else if (isErrorType(err, errors.NoSuchDriverError)) {
+    // respond with a 404 if there is no driver for the session
+    httpStatus = 404;
   }
 
 

--- a/test/mjsonwp-specs.js
+++ b/test/mjsonwp-specs.js
@@ -340,7 +340,7 @@ describe('MJSONWP', async () => {
         simple: false
       });
 
-      res.statusCode.should.equal(500);
+      res.statusCode.should.equal(404);
       res.body.should.eql({
         status: 6,
         value: {
@@ -402,7 +402,7 @@ describe('MJSONWP', async () => {
         simple: false
       });
 
-      res.statusCode.should.equal(500);
+      res.statusCode.should.equal(404);
       res.body.status.should.equal(6);
       res.body.value.message.should.contain('session');
     });
@@ -419,7 +419,7 @@ describe('MJSONWP', async () => {
         simple: false
       });
 
-      res.statusCode.should.equal(500);
+      res.statusCode.should.equal(404);
       res.body.status.should.equal(6);
       res.body.value.message.should.contain('session');
     });


### PR DESCRIPTION
We should return a 404 error when a session id does not map to a valid session. From the spec

    "If a request path maps to a variable resource, but that resource does not exist, 
    then the server should respond with a 404 Not Found. For example, if ID my-session 
    is not a valid session ID on the server, and a command is sent to 
    GET /session/my-session HTTP/1.1, then the server should gracefully return a 404."

https://code.google.com/p/selenium/wiki/JsonWireProtocol#Error_Handling