### PR TITLE
Added new route for simulator Touch ID command

### DIFF
--- a/docs/protocol-methods.md
+++ b/docs/protocol-methods.md
@@ -127,6 +127,7 @@ POST        | `/wd/hub/session/{sessionId}/appium/device/toggle_wifi`           
 POST        | `/wd/hub/session/{sessionId}/appium/device/toggle_location_services`   | Switch the state of the location service.
 POST        | `/wd/hub/session/{sessionId}/appium/device/open_notifications`         | Open the notifications pane on the device.
 POST        | `/wd/hub/session/{sessionId}/appium/device/start_activity`             | Start the specified activity on the device.
+POST        | `/wd/hub/session/{sessionId}/appium/simulator/touch_id`                | Simulate a successful or failed touch id event on the simulator.
 POST        | `/wd/hub/session/{sessionId}/appium/app/launch`                        | Launch the given application on the device.
 POST        | `/wd/hub/session/{sessionId}/appium/app/close`                         | Close the given application.
 POST        | `/wd/hub/session/{sessionId}/appium/app/reset`                         | Reset the device.

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -359,6 +359,9 @@ const METHOD_MAP = {
   '/wd/hub/session/:sessionId/appium/device/start_activity': {
     POST: {command: 'startActivity', payloadParams: {required: ['appPackage', 'appActivity']}}
   },
+  '/wd/hub/session/:sessionId/appium/simulator/touch_id': {
+    POST: {command: 'touchId', payloadParams: {required: ['match']}}
+  },
   '/wd/hub/session/:sessionId/appium/app/launch': {
     POST: {command: 'launchApp'}
   },

--- a/test/routes-specs.js
+++ b/test/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('16d9dfdb');
+      hash.should.equal('7711b8be');
     });
   });
 


### PR DESCRIPTION
There is now support for sending TouchID “match” and “no match” commands in iOS (in facebook/WebDriverAgent). appium-xctest-driver needs to add the method, along with the client libraries, but first of all this code needs the route for it.