### PR TITLE
Allow for multiple sets of possible required parameters

### DIFF
--- a/lib/mjsonwp.js
+++ b/lib/mjsonwp.js
@@ -63,29 +63,49 @@ function checkParams (paramSets, jsonObj) {
     }
   }
 
+  // if we have no required parameters, all is well
+  if (requiredParams.length === 0) {
+    return;
+  }
+
   // some clients pass in the session id in the params
   optionalParams.push('sessionId');
 
   // some clients pass in an element id in the params
   optionalParams.push('id');
 
+  // go through the required parameters and check against our arguments
   for (let params of requiredParams) {
     if (_.difference(receivedParams, params, optionalParams).length === 0 &&
         _.difference(params, receivedParams).length === 0) {
       // we have a set of parameters that is correct
       // so short-circuit
       return;
-    } else {
-      throw new errors.BadParametersError(paramSets, receivedParams);
     }
   }
+  throw new errors.BadParametersError(paramSets, receivedParams);
 }
 
 function makeArgs (reqParams, jsonObj, payloadParams) {
   // we want to pass the url parameters to the commands in reverse order
   // since the command will sometimes want to ignore, say, the sessionId
   let urlParams = _.keys(reqParams).reverse();
-  let args = _.flatten(payloadParams.required).map(p => jsonObj[p]);
+
+  // there can be multiple sets of required params, so find the correct one
+  let realRequiredParams = payloadParams.required;
+  if (_.isArray(_.first(payloadParams.required))) {
+    let keys = _.keys(jsonObj);
+    for (let params of payloadParams.required) {
+      // check if all the required parameters are in the json object
+      if (_.without(params, ...keys).length === 0) {
+        // we have all the parameters for this set
+        realRequiredParams = params;
+        break;
+      }
+    }
+  }
+  let args = _.flatten(realRequiredParams).map(p => jsonObj[p]);
+
   if (payloadParams.optional) {
     args = args.concat(_.flatten(payloadParams.optional).map(p => jsonObj[p]));
   }
@@ -178,7 +198,6 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
 
       // ensure that the json payload conforms to the spec
       checkParams(spec.payloadParams, jsonObj);
-
       // ensure the session the user is trying to use is valid
       if (isSessCmd && !driver.sessionExists(req.params.sessionId)) {
         throw new errors.NoSuchDriverError();
@@ -188,12 +207,10 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // the driver methods
       let args = makeArgs(req.params, jsonObj, spec.payloadParams || []);
       let driverRes;
-
       // validate command args according to MJSONWP
       if (validators[spec.command]) {
         validators[spec.command](...args);
       }
-
       // run the driver command wrapped inside the argument validators
       log.info(`Calling ${driver.constructor.name}.${spec.command}() with args: ` +
                 _.trunc(JSON.stringify(args), LOG_OBJ_LENGTH));

--- a/test/fake-driver.js
+++ b/test/fake-driver.js
@@ -104,6 +104,10 @@ class FakeDriver extends MobileJsonWireProtocol {
     return frameId;
   }
 
+  async removeApp (app) {
+    return app;
+  }
+
   proxyActive (/*sessionId*/) {
     return false;
   }

--- a/test/mjsonwp-specs.js
+++ b/test/mjsonwp-specs.js
@@ -142,7 +142,7 @@ describe('MJSONWP', async () => {
 
     // TODO pass this test
     // https://github.com/appium/node-mobile-json-wire-protocol/issues/3
-    it.skip('4xx responses should have content-type of text/plain', async () => {
+    it('4xx responses should have content-type of text/plain', async () => {
       let res = await request({
         url: 'http://localhost:8181/wd/hub/blargimargarita',
         method: 'GET',
@@ -150,7 +150,7 @@ describe('MJSONWP', async () => {
         simple: false // 404 errors fulfill the promise, rather than rejecting
       });
 
-      res.headers['content-type'].should.eql('text/plain');
+      res.headers['content-type'].should.include('text/plain');
     });
 
     it('should throw not yet implemented for unfilledout commands', async () => {
@@ -222,23 +222,45 @@ describe('MJSONWP', async () => {
     });
 
     describe('multiple sets of arguments', () => {
-      it('should allow moveto with element', async () => {
-        let res = await request({
-          url: 'http://localhost:8181/wd/hub/session/foo/moveto',
-          method: 'POST',
-          json: {element: '3'}
+      describe('optional', () => {
+        it('should allow moveto with element', async () => {
+          let res = await request({
+            url: 'http://localhost:8181/wd/hub/session/foo/moveto',
+            method: 'POST',
+            json: {element: '3'}
+          });
+          res.status.should.equal(0);
+          res.value.should.eql(['3', null, null]);
         });
-        res.status.should.equal(0);
-        res.value.should.eql(['3', null, null]);
+        it('should allow moveto with xoffset/yoffset', async () => {
+          let res = await request({
+            url: 'http://localhost:8181/wd/hub/session/foo/moveto',
+            method: 'POST',
+            json: {xoffset: 42, yoffset: 17}
+          });
+          res.status.should.equal(0);
+          res.value.should.eql([null, 42, 17]);
+        });
       });
-      it('should allow moveto with xoffset/yoffset', async () => {
-        let res = await request({
-          url: 'http://localhost:8181/wd/hub/session/foo/moveto',
-          method: 'POST',
-          json: {xoffset: 42, yoffset: 17}
+      describe('required', () => {
+        it('should allow removeApp with appId', async () => {
+          let res = await request({
+            url: 'http://localhost:8181/wd/hub/session/foo/appium/device/remove_app',
+            method: 'POST',
+            json: {appId: 42}
+          });
+          res.status.should.equal(0);
+          res.value.should.eql(42);
         });
-        res.status.should.equal(0);
-        res.value.should.eql([null, 42, 17]);
+        it('should allow removeApp with bundleId', async () => {
+          let res = await request({
+            url: 'http://localhost:8181/wd/hub/session/foo/appium/device/remove_app',
+            method: 'POST',
+            json: {bundleId: 42}
+          });
+          res.status.should.equal(0);
+          res.value.should.eql(42);
+        });
       });
     });
 

--- a/test/routes-specs.js
+++ b/test/routes-specs.js
@@ -38,7 +38,7 @@ describe('MJSONWP', () => {
       }
       var hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('7711b8be');
+      hash.should.equal('261a2f0b');
     });
   });
 


### PR DESCRIPTION
There were cases where two or more different sets of required parameters could be passed in, which caused a failure.

See https://github.com/appium/java-client/issues/302