### PR TITLE
Make metastate optional for pressing keycodes

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -304,10 +304,10 @@ const METHOD_MAP = {
     POST: {command: 'isLocked'}
   },
   '/wd/hub/session/:sessionId/appium/device/press_keycode': {
-    POST: {command: 'pressKeyCode', payloadParams: {required: ['keycode', 'metastate']}}
+    POST: {command: 'pressKeyCode', payloadParams: {required: ['keycode'], optional: ['metastate']}}
   },
   '/wd/hub/session/:sessionId/appium/device/long_press_keycode': {
-    POST: {command: 'longPressKeyCode', payloadParams: {required: ['keycode', 'metastate']}}
+    POST: {command: 'longPressKeyCode', payloadParams: {required: ['keycode'], optional: ['metastate']}}
   },
   '/wd/hub/session/:sessionId/appium/device/keyevent': {
     POST: {command: 'keyevent', payloadParams: {required: ['keycode'], optional: ['metastate']}}


### PR DESCRIPTION
Metastate should not be required for `press_keycode` and `long_press_keycode`. See https://github.com/appium/appium/issues/5937