### PR TITLE
Make seconds optional for lock command

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -295,7 +295,7 @@ const METHOD_MAP = {
     GET: {command: 'getDeviceTime'}
   },
   '/wd/hub/session/:sessionId/appium/device/lock': {
-    POST: {command: 'lock', payloadParams: {required: ['seconds']}}
+    POST: {command: 'lock', payloadParams: {optional: ['seconds']}}
   },
   '/wd/hub/session/:sessionId/appium/device/unlock': {
     POST: {command: 'unlock'}


### PR DESCRIPTION
Android does not take seconds, so this needs to be optional.