### PR TITLE
Make sure to check session before we do anything else

### DIFF
--- a/lib/mjsonwp.js
+++ b/lib/mjsonwp.js
@@ -169,6 +169,12 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
     let httpStatus = 200;
     let newSessionId;
     try {
+      // if this is a session command but we don't have a session,
+      // error out early (especially before proxying)
+      if (isSessCmd && !driver.sessionExists(req.params.sessionId)) {
+        throw new errors.NoSuchDriverError();
+      }
+
       // if the driver is currently proxying commands to another JSONWP
       // server, bypass all our checks and assume the upstream server knows
       // what it's doing. But keep this in the try/catch block so if proxying
@@ -199,9 +205,6 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // ensure that the json payload conforms to the spec
       checkParams(spec.payloadParams, jsonObj);
       // ensure the session the user is trying to use is valid
-      if (isSessCmd && !driver.sessionExists(req.params.sessionId)) {
-        throw new errors.NoSuchDriverError();
-      }
 
       // turn the command and json payload into an argument list for
       // the driver methods


### PR DESCRIPTION
When we are proxying we would get an uncaught error rather than the correct "session does not exist" error. Move the check earlier to short circuit.