### PR TITLE
Only unwrap parameters if it seems wrapped

### DIFF
--- a/lib/mjsonwp.js
+++ b/lib/mjsonwp.js
@@ -37,7 +37,10 @@ function unwrapParams (paramSets, jsonObj) {
    */
   let res = jsonObj;
   if (_.isObject(jsonObj)) {
-    res = jsonObj[paramSets.unwrap];
+    // some clients, like ruby, don't wrap
+    if (jsonObj[paramSets.unwrap]) {
+      res = jsonObj[paramSets.unwrap];
+    }
   }
   return res;
 }


### PR DESCRIPTION
Some clients (like ruby) don't wrap the parameters that others wrap. So instead of unwrapping willy-nilly, check that the unwrapped parameter is there, and unwrap.

Fixes https://github.com/appium/appium/issues/6290